### PR TITLE
Add Makefile and Mint support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+PREFIX ?= /usr/local
+BINARY = backdrop
+BUILD_DIR = $(shell swift build --show-bin-path -c release 2>/dev/null || echo .build/release)
+
+.PHONY: build install uninstall test clean
+
+build:
+	swift build --disable-sandbox -c release
+
+install: build
+	install -d $(PREFIX)/bin
+	install $(BUILD_DIR)/$(BINARY) $(PREFIX)/bin/$(BINARY)
+
+uninstall:
+	rm -f $(PREFIX)/bin/$(BINARY)
+
+test:
+	swift test
+
+clean:
+	swift package clean


### PR DESCRIPTION
## Summary
- Add Makefile with `build`, `install`, `uninstall`, `test`, `clean` targets
- Package.swift already has executable product, so Mint (`mint install GeneralD/backdrop`) works out of the box

Closes #1