### PR TITLE
Replace hand-rolled hex parsing with SwiftHEXColors

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "df851d7378fa95184863e95559f31eb1fcad0e6f77dfdf2193b3fb9d0129000c",
+  "originHash" : "aa036ed99e00772b6eb690d09a52c9ed397f5cca08b99c457ab69bc875fcc482",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -62,6 +62,15 @@
       "state" : {
         "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
         "version" : "602.0.0"
+      }
+    },
+    {
+      "identity" : "swifthexcolors",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/thii/SwiftHEXColors",
+      "state" : {
+        "revision" : "1f886cb20fedda14a5ac75efd09bc99c95b43a18",
+        "version" : "1.4.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.6.0"),
         .package(url: "https://github.com/groue/GRDB.swift", from: "7.0.0"),
         .package(url: "https://github.com/LebJe/TOMLKit", from: "0.6.0"),
+        .package(url: "https://github.com/thii/SwiftHEXColors", from: "1.4.1"),
     ],
     targets: [
         // Core domain — zero external dependencies except swift-dependencies
@@ -37,6 +38,7 @@ let package = Package(
             dependencies: [
                 "BackdropDomain",
                 .product(name: "TOMLKit", package: "TOMLKit"),
+                .product(name: "SwiftHEXColors", package: "SwiftHEXColors"),
             ]
         ),
         .target(
@@ -64,7 +66,11 @@ let package = Package(
         // Presentation
         .target(
             name: "BackdropUI",
-            dependencies: ["BackdropDomain", "BackdropConfig"]
+            dependencies: [
+                "BackdropDomain",
+                "BackdropConfig",
+                .product(name: "SwiftHEXColors", package: "SwiftHEXColors"),
+            ]
         ),
 
         // App wiring

--- a/Sources/BackdropConfig/HexColor.swift
+++ b/Sources/BackdropConfig/HexColor.swift
@@ -1,21 +1,7 @@
+import SwiftHEXColors
 import SwiftUI
 
 public func parseHexColor(_ hex: String) -> Color {
-    let h = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
-    guard h.count == 6 || h.count == 8,
-          let value = UInt64(h, radix: 16) else { return .white }
-    let r, g, b, a: Double
-    switch h.count {
-    case 8:
-        r = Double((value >> 24) & 0xFF) / 255
-        g = Double((value >> 16) & 0xFF) / 255
-        b = Double((value >> 8) & 0xFF) / 255
-        a = Double(value & 0xFF) / 255
-    default:
-        r = Double((value >> 16) & 0xFF) / 255
-        g = Double((value >> 8) & 0xFF) / 255
-        b = Double(value & 0xFF) / 255
-        a = 1
-    }
-    return Color(red: r, green: g, blue: b, opacity: a)
+    guard let nsColor = NSColor(hexString: hex) else { return .white }
+    return Color(nsColor: nsColor)
 }

--- a/Sources/BackdropUI/Views/RippleView.swift
+++ b/Sources/BackdropUI/Views/RippleView.swift
@@ -1,6 +1,7 @@
 import AppKit
 import BackdropDomain
 import Dependencies
+import SwiftHEXColors
 import SwiftUI
 
 @MainActor
@@ -17,7 +18,8 @@ public struct RippleView: View {
 
     public var body: some View {
         let rc = config.ripple
-        let baseNSColor = NSColor(hexString: rc.colorHex)
+        let baseNSColor = (NSColor(hexString: rc.colorHex) ?? .white)
+            .usingColorSpace(.deviceRGB) ?? .white
 
         TimelineView(.animation) { timeline in
             Canvas { context, size in
@@ -46,30 +48,5 @@ public struct RippleView: View {
                 }
             }
         }
-    }
-}
-
-extension NSColor {
-    convenience init(hexString: String) {
-        let h = hexString.hasPrefix("#") ? String(hexString.dropFirst()) : hexString
-        guard h.count == 6 || h.count == 8,
-              let value = UInt64(h, radix: 16) else {
-            self.init(white: 1, alpha: 1)
-            return
-        }
-        let r, g, b, a: CGFloat
-        switch h.count {
-        case 8:
-            r = CGFloat((value >> 24) & 0xFF) / 255
-            g = CGFloat((value >> 16) & 0xFF) / 255
-            b = CGFloat((value >> 8) & 0xFF) / 255
-            a = CGFloat(value & 0xFF) / 255
-        default:
-            r = CGFloat((value >> 16) & 0xFF) / 255
-            g = CGFloat((value >> 8) & 0xFF) / 255
-            b = CGFloat(value & 0xFF) / 255
-            a = 1
-        }
-        self.init(red: r, green: g, blue: b, alpha: a)
     }
 }


### PR DESCRIPTION
## Summary
- Add SwiftHEXColors dependency
- Replace `parseHexColor` (21 lines) and `NSColor(hexString:)` (24 lines) with library calls
- Net -22 lines of custom code

Closes #4