### PR TITLE
Introduce CollectionKit for declarative collection operations

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "aa036ed99e00772b6eb690d09a52c9ed397f5cca08b99c457ab69bc875fcc482",
+  "originHash" : "92fd719f3c20d4f930222f020b215be494c417398c0a2c88d1b54796de2a872a",
   "pins" : [
+    {
+      "identity" : "collectionkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/GeneralD/CollectionKit",
+      "state" : {
+        "revision" : "e1ae3fef8fd3be72c309fd20d7e56e9db30827db",
+        "version" : "1.0.1"
+      }
+    },
     {
       "identity" : "combine-schedulers",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         .package(url: "https://github.com/groue/GRDB.swift", from: "7.0.0"),
         .package(url: "https://github.com/LebJe/TOMLKit", from: "0.6.0"),
         .package(url: "https://github.com/thii/SwiftHEXColors", from: "1.4.1"),
+        .package(url: "https://github.com/GeneralD/CollectionKit", from: "1.0.0"),
     ],
     targets: [
         // Core domain — zero external dependencies except swift-dependencies
@@ -22,6 +23,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Dependencies", package: "swift-dependencies"),
                 .product(name: "DependenciesMacros", package: "swift-dependencies"),
+                .product(name: "CollectionKit", package: "CollectionKit"),
             ]
         ),
 
@@ -43,7 +45,10 @@ let package = Package(
         ),
         .target(
             name: "BackdropLRCLib",
-            dependencies: ["BackdropDomain"]
+            dependencies: [
+                "BackdropDomain",
+                .product(name: "CollectionKit", package: "CollectionKit"),
+            ]
         ),
         .target(
             name: "BackdropPersistence",
@@ -70,6 +75,7 @@ let package = Package(
                 "BackdropDomain",
                 "BackdropConfig",
                 .product(name: "SwiftHEXColors", package: "SwiftHEXColors"),
+                .product(name: "CollectionKit", package: "CollectionKit"),
             ]
         ),
 

--- a/Sources/BackdropDomain/TitleParser.swift
+++ b/Sources/BackdropDomain/TitleParser.swift
@@ -1,34 +1,38 @@
+import CollectionKit
+
 public struct TitleParser: Sendable {
-    private static let noiseWords: Set<String> = [
-        "mv", "pv", "official video", "official music video", "music video",
-        "lyric video", "lyrics video", "the first take", "audio", "official audio",
-        "full ver.", "full version", "short ver.", "short version", "topic", "vevo",
-    ]
-
-    private static let bracketPatterns = [
-        "【[^】]*】", "「[^」]*」", "『[^』]*』",
-        "\\([^)]*\\)", "（[^）]*）", "\\[[^\\]]*\\]",
-    ]
-
     public init() {}
+}
 
+private let noiseWords: Set<String> = [
+    "mv", "pv", "official video", "official music video", "music video",
+    "lyric video", "lyrics video", "the first take", "audio", "official audio",
+    "full ver.", "full version", "short ver.", "short version", "topic", "vevo",
+]
+
+private let bracketPatterns = [
+    "【[^】]*】", "「[^」]*」", "『[^』]*』",
+    "\\([^)]*\\)", "（[^）]*）", "\\[[^\\]]*\\]",
+]
+
+extension TitleParser {
     public func stripBrackets(_ s: String) -> String {
-        Self.bracketPatterns.reduce(s) { result, pattern in
-            result.replacingOccurrences(of: pattern, with: "", options: .regularExpression)
-        }.trimmingCharacters(in: .whitespaces)
+        bracketPatterns
+            .reduce(s) { $0.replacingOccurrences(of: $1, with: "", options: .regularExpression) }
+            .trimmingCharacters(in: .whitespaces)
     }
 
     public func isNoise(_ s: String) -> Bool {
         let trimmed = s.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return true }
-        return Self.noiseWords.contains(trimmed.lowercased())
+        return noiseWords.contains(trimmed.lowercased())
     }
 
     public func splitTitle(_ title: String) -> [String] {
         [" - ", " / ", " | ", "｜"]
             .reduce([title]) { parts, sep in parts.flatMap { $0.components(separatedBy: sep) } }
             .map { stripBrackets($0).trimmingCharacters(in: .whitespaces) }
-            .filter { !isNoise($0) }
+            .unless(isNoise)
     }
 
     public func generateCandidates(title: String, artist: String) -> [SearchCandidate] {
@@ -36,23 +40,21 @@ public struct TitleParser: Sendable {
         let cleaned = stripBrackets(title)
         let artistUsable = !isNoise(artist)
 
-        let candidates: [SearchCandidate] = [
+        var seen = Set<String>()
+        return [
             artistUsable ? [SearchCandidate(title: cleaned, artist: artist)] : [],
             parts.count >= 2
                 ? [SearchCandidate(title: parts[1], artist: parts[0]),
                    SearchCandidate(title: parts[0], artist: parts[1])]
                 : [],
             artistUsable
-                ? parts.filter { $0 != cleaned }.map { SearchCandidate(title: $0, artist: artist) }
+                ? parts.unless { $0 == cleaned }.map { SearchCandidate(title: $0, artist: artist) }
                 : [],
             parts.count == 1 && !artistUsable
                 ? [SearchCandidate(title: parts[0], artist: "")]
                 : [],
-        ].flatMap { $0 }
-
-        var seen = Set<String>()
-        return candidates.filter { c in
-            seen.insert("\(c.title.lowercased())|\(c.artist.lowercased())").inserted
-        }
+        ]
+        .flatten
+        .filter { seen.insert("\($0.title.lowercased())|\($0.artist.lowercased())").inserted }
     }
 }

--- a/Sources/BackdropLRCLib/LRCLibClient.swift
+++ b/Sources/BackdropLRCLib/LRCLibClient.swift
@@ -1,4 +1,5 @@
 import BackdropDomain
+import CollectionKit
 import Dependencies
 import Foundation
 
@@ -10,7 +11,7 @@ public struct LRCLibClient: LyricsRepository, Sendable {
         let candidates = parser.generateCandidates(title: title, artist: artist)
 
         let getResults = await candidates
-            .filter { !$0.artist.isEmpty }
+            .unless(\.artist.isEmpty)
             .asyncCompactMap { await get(title: $0.title, artist: $0.artist, duration: duration) }
             .filter { $0.plainLyrics != nil }
 

--- a/Sources/BackdropUI/Views/LyricsColumnView.swift
+++ b/Sources/BackdropUI/Views/LyricsColumnView.swift
@@ -1,4 +1,5 @@
 import BackdropDomain
+import CollectionKit
 import SwiftUI
 
 struct Column: Identifiable {


### PR DESCRIPTION
## Summary
- Add CollectionKit dependency (by @GeneralD)
- Replace `.filter { !... }` with `.unless(...)` / `.unless(\.keyPath)`
- Replace `.flatMap { $0 }` with `.flatten`
- Move TitleParser constants to file scope, functions to extension

Note: `lines[].text` (array chaining) couldn't be used due to access level — tracked for CollectionKit improvement.

Closes #6