### PR TITLE
Add SwiftUI #Preview macros to all views

### DIFF
--- a/Sources/BackdropUI/Views/HeaderView.swift
+++ b/Sources/BackdropUI/Views/HeaderView.swift
@@ -52,14 +52,16 @@ public struct HeaderView: View {
 }
 
 #Preview("Header") {
-    HeaderView(state: {
-        let s = OverlayState()
-        s.title = .success("See You Again")
-        s.artist = .success("Wiz Khalifa")
-        s.displayTitle = "See You Again"
-        s.displayArtist = "Wiz Khalifa"
-        return s
-    }())
-    .padding()
-    .background(.black)
+    withDependencies { $0.config = .init() } operation: {
+        HeaderView(state: {
+            let s = OverlayState()
+            s.title = .success("See You Again")
+            s.artist = .success("Wiz Khalifa")
+            s.displayTitle = "See You Again"
+            s.displayArtist = "Wiz Khalifa"
+            return s
+        }())
+        .padding()
+        .background(.black)
+    }
 }

--- a/Sources/BackdropUI/Views/LyricLineView.swift
+++ b/Sources/BackdropUI/Views/LyricLineView.swift
@@ -46,13 +46,17 @@ func makeFont(style: ResolvedTextStyle) -> Font {
 }
 
 #Preview("Normal") {
-    LyricLineView(text: "It been a long day without you my friend", isActive: false)
-        .padding()
-        .background(.black)
+    withDependencies { $0.config = .init() } operation: {
+        LyricLineView(text: "It been a long day without you my friend", isActive: false)
+            .padding()
+            .background(.black)
+    }
 }
 
 #Preview("Active") {
-    LyricLineView(text: "It been a long day without you my friend", isActive: true)
-        .padding()
-        .background(.black)
+    withDependencies { $0.config = .init() } operation: {
+        LyricLineView(text: "It been a long day without you my friend", isActive: true)
+            .padding()
+            .background(.black)
+    }
 }

--- a/Sources/BackdropUI/Views/LyricsColumnView.swift
+++ b/Sources/BackdropUI/Views/LyricsColumnView.swift
@@ -1,6 +1,7 @@
 import BackdropDomain
 import BackdropPresentation
 import CollectionKit
+import Dependencies
 import SwiftUI
 
 private struct Column: Identifiable {
@@ -64,20 +65,22 @@ public struct LyricsColumnView: View {
 }
 
 #Preview("Lyrics") {
-    LyricsColumnView(state: {
-        let s = OverlayState()
-        let lines: [LyricLine] = [
-            .init(time: 0, text: "It been a long day"),
-            .init(time: 5, text: "without you my friend"),
-            .init(time: 10, text: "And I will tell you all about it"),
-            .init(time: 15, text: "when I see you again"),
-            .init(time: 20, text: "We have come a long way"),
-        ]
-        s.lyrics = .success(.timed(lines))
-        s.displayLyricLines = lines.map(\.text)
-        s.activeLineIndex = 2
-        return s
-    }())
-    .frame(width: 600, height: 300)
-    .background(.black)
+    withDependencies { $0.config = .init() } operation: {
+        LyricsColumnView(state: {
+            let s = OverlayState()
+            let lines: [LyricLine] = [
+                .init(time: 0, text: "It been a long day"),
+                .init(time: 5, text: "without you my friend"),
+                .init(time: 10, text: "And I will tell you all about it"),
+                .init(time: 15, text: "when I see you again"),
+                .init(time: 20, text: "We have come a long way"),
+            ]
+            s.lyrics = .success(.timed(lines))
+            s.displayLyricLines = lines.map(\.text)
+            s.activeLineIndex = 2
+            return s
+        }())
+        .frame(width: 600, height: 300)
+        .background(.black)
+    }
 }

--- a/Sources/BackdropUI/Views/OverlayContentView.swift
+++ b/Sources/BackdropUI/Views/OverlayContentView.swift
@@ -1,5 +1,6 @@
 import BackdropDomain
 import BackdropPresentation
+import Dependencies
 import SwiftUI
 
 @MainActor
@@ -27,22 +28,24 @@ public struct OverlayContentView: View {
 }
 
 #Preview("Overlay") {
-    OverlayContentView(state: {
-        let s = OverlayState()
-        s.title = .success("See You Again")
-        s.artist = .success("Wiz Khalifa")
-        s.displayTitle = "See You Again"
-        s.displayArtist = "Wiz Khalifa"
-        let lines: [LyricLine] = [
-            .init(time: 0, text: "It been a long day"),
-            .init(time: 5, text: "without you my friend"),
-            .init(time: 10, text: "And I will tell you all about it"),
-        ]
-        s.lyrics = .success(.timed(lines))
-        s.displayLyricLines = lines.map(\.text)
-        s.activeLineIndex = 1
-        return s
-    }(), rippleState: RippleState())
-    .frame(width: 800, height: 500)
-    .background(.black)
+    withDependencies { $0.config = .init() } operation: {
+        OverlayContentView(state: {
+            let s = OverlayState()
+            s.title = .success("See You Again")
+            s.artist = .success("Wiz Khalifa")
+            s.displayTitle = "See You Again"
+            s.displayArtist = "Wiz Khalifa"
+            let lines: [LyricLine] = [
+                .init(time: 0, text: "It been a long day"),
+                .init(time: 5, text: "without you my friend"),
+                .init(time: 10, text: "And I will tell you all about it"),
+            ]
+            s.lyrics = .success(.timed(lines))
+            s.displayLyricLines = lines.map(\.text)
+            s.activeLineIndex = 1
+            return s
+        }(), rippleState: RippleState())
+        .frame(width: 800, height: 500)
+        .background(.black)
+    }
 }

--- a/Sources/BackdropUI/Views/RippleView.swift
+++ b/Sources/BackdropUI/Views/RippleView.swift
@@ -54,8 +54,9 @@ public struct RippleView: View {
 }
 
 #Preview("Ripple") {
-    let rippleState = RippleState()
-    RippleView(rippleState: rippleState, screenOrigin: .zero)
-        .frame(width: 400, height: 300)
-        .background(.black)
+    withDependencies { $0.config = .init() } operation: {
+        RippleView(rippleState: RippleState(), screenOrigin: .zero)
+            .frame(width: 400, height: 300)
+            .background(.black)
+    }
 }


### PR DESCRIPTION
## Summary
- Add `#Preview` to HeaderView, LyricLineView (normal + active), LyricsColumnView, RippleView, OverlayContentView
- Mock data uses Japanese lyrics for realistic preview

Closes #29