### PR TITLE
Auto-update homebrew formula on tag push

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,52 @@
+name: Update Homebrew Formula
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  update-formula:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "TAG=$GITHUB_REF_NAME" >> "$GITHUB_ENV"
+          echo "Updating formula for $GITHUB_REF_NAME"
+
+      - name: Download tarball and compute sha256
+        run: |
+          URL="https://github.com/${{ github.repository }}/archive/refs/tags/${TAG}.tar.gz"
+          curl -sL "$URL" -o release.tar.gz
+          SHA256=$(sha256sum release.tar.gz | awk '{print $1}')
+          echo "SHA256=$SHA256" >> "$GITHUB_ENV"
+          echo "SHA256: $SHA256"
+
+      - name: Update formula in homebrew-private
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.HOMEBREW_PAT }}
+          script: |
+            const owner = 'GeneralD';
+            const repo = 'homebrew-private';
+            const path = 'Formula/backdrop.rb';
+            const version = process.env.VERSION;
+            const tag = process.env.TAG;
+            const sha256 = process.env.SHA256;
+
+            const { data: file } = await github.rest.repos.getContent({ owner, repo, path });
+            const content = Buffer.from(file.content, 'base64').toString('utf8');
+
+            const updated = content
+              .replace(/url ".*"/, `url "https://github.com/GeneralD/backdrop/archive/refs/tags/${tag}.tar.gz"`)
+              .replace(/sha256 ".*"/, `sha256 "${sha256}"`);
+
+            await github.rest.repos.createOrUpdateFileContents({
+              owner, repo, path,
+              message: `Update backdrop to ${version}`,
+              content: Buffer.from(updated).toString('base64'),
+              sha: file.sha,
+            });
+
+            console.log(`Updated formula to ${version}`);


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow triggered by `v*` tag push
- Downloads release tarball, computes sha256
- Updates `Formula/backdrop.rb` in `GeneralD/homebrew-private` via GitHub API

## Setup Required
Add `HOMEBREW_PAT` secret to this repo (PAT with `repo` scope for `GeneralD/homebrew-private`)

Closes #35