### PR TITLE
Use system font as default

### DIFF
--- a/Sources/BackdropConfig/AppConfig.swift
+++ b/Sources/BackdropConfig/AppConfig.swift
@@ -274,7 +274,7 @@ extension AppConfig {
 extension TextStyleConfig {
     @MainActor
     func resolve() -> ResolvedTextStyle {
-        let fontName = font ?? "Zen Maru Gothic"
+        let fontName = font ?? NSFont.systemFont(ofSize: 0).familyName ?? ".AppleSystemUIFont"
         let fontSize = size ?? 12
         let fontWeight = weight ?? "regular"
         let spacing = spacing ?? 6

--- a/Sources/BackdropDomain/Dependencies/ConfigProvider.swift
+++ b/Sources/BackdropDomain/Dependencies/ConfigProvider.swift
@@ -89,7 +89,7 @@ public struct ResolvedTextStyle: Sendable {
 
     public init(
         spacing: Double = 6,
-        fontName: String = "Zen Maru Gothic",
+        fontName: String = ".AppleSystemUIFont",
         fontSize: Double = 12,
         fontWeight: String = "regular",
         color: ColorStyle = .solid("#FFFFFFD9"),


### PR DESCRIPTION
## Summary
- Change default font from "Zen Maru Gothic" to system font
- Users without Zen Maru Gothic installed no longer get fallback behavior

Note: #41 (config file watching) was closed — config changes are applied via `backdrop restart`.