### PR TITLE
Expand README with full configuration reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,47 +42,123 @@ lyra service uninstall
 eval "$(lyra completion zsh)"
 ```
 
+Homebrew installs completions automatically.
+
 ## Configuration
 
-`~/.config/lyra/config.toml`
+Create `~/.config/lyra/config.toml` (or `config.json`). All fields are optional — missing values use sensible defaults.
+
+Alternative paths: `~/.lyra/config.toml`, `$XDG_CONFIG_HOME/lyra/config.toml`
+
+### Top-level
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `screen` | string / int | `"main"` | Which display to use (see [Screen selection](#screen-selection)) |
+| `wallpaper` | string | — | Video file path. Relative to config dir or absolute |
+
+### `[text.default]` — base text style
+
+All text sections inherit from `[text.default]`. Section-specific values override the base.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `font` | string | system font | Font family name (e.g. `"Helvetica Neue"`) |
+| `size` | number | `12` | Font size in points |
+| `weight` | string | `"regular"` | Font weight: `"regular"`, `"medium"`, `"bold"`, etc. |
+| `color` | string / array | `"#FFFFFFD9"` | Solid hex `"#RRGGBBAA"` or gradient `["#AAA", "#BBB"]` |
+| `shadow` | string | `"#000000E6"` | Shadow color in hex |
+| `spacing` | number | `6` | Vertical padding around each line |
+
+### `[text.title]`, `[text.artist]`, `[text.lyric]`, `[text.highlight]`
+
+Each overrides specific properties from `[text.default]`. Unset properties fall back to the base.
+
+| Section | Built-in overrides |
+|---|---|
+| `title` | `size = 18`, `weight = "bold"` |
+| `artist` | `weight = "medium"` |
+| `lyric` | inherits default as-is |
+| `highlight` | `color = ["#B8942DFF", "#EDCF73FF", "#FFEB99FF", "#CCA64DFF", "#A68038FF"]` (gold gradient). Inherits from `lyric`, then `default` |
+
+### `[text.decode_effect]`
+
+Controls the matrix-style text reveal animation.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `duration` | number | `0.8` | Animation duration in seconds |
+| `charset` | string / array | all | Character sets for scramble: `"latin"`, `"cyrillic"`, `"greek"`, `"symbols"`. Single string or array |
+
+### `[artwork]`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `size` | number | `96` | Album artwork size in points |
+| `opacity` | number | `1.0` | `0` hides artwork (text aligns left), `1` fully visible |
+
+### `[ripple]`
+
+Mouse-reactive ripple effect on the overlay.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `color` | string | `"#AAAAFFFF"` | Ripple color in hex |
+| `radius` | number | `60` | Ripple radius in points |
+| `duration` | number | `0.6` | Ripple animation duration in seconds |
+| `idle` | number | `1` | Seconds before ripple fades after mouse stops |
+
+### Screen selection
+
+| Value | Behavior |
+|---|---|
+| `"main"` | Current main display (with focused window) |
+| `"primary"` | Primary display (menu bar screen) |
+| `"smallest"` | Smallest display by area |
+| `"largest"` | Largest display by area |
+| `"match"` | Best aspect-ratio match for the wallpaper video |
+| `0`, `1`, … | Display by index |
+
+### Full example
 
 ```toml
-screen = "match"           # main, primary, smallest, largest, match, or index
-wallpaper = "koko.mp4"     # relative to config dir, or absolute path
+screen = "main"
+# wallpaper = "loop.mp4"
 
 [text.default]
-font = "Zen Maru Gothic"
-size = 12
-color = "#FFFFFFD9"        # solid color or gradient array
+font = "Helvetica Neue"
+size = 14
+color = "#FFFFFFD9"
 shadow = "#000000E6"
-spacing = 6
+spacing = 8
 
 [text.title]
-size = 18
+size = 20
+weight = "bold"
 
 [text.artist]
-size = 12
+weight = "medium"
+
+[text.lyric]
+color = "#FFFFFFE6"
 
 [text.highlight]
 color = ["#B8942DFF", "#EDCF73FF", "#FFEB99FF", "#CCA64DFF", "#A68038FF"]
-# size, spacing, font, weight, shadow also supported
 
 [text.decode_effect]
-duration = 0.8                       # seconds for decode animation
-charset = ["latin", "cyrillic"]      # latin, cyrillic, greek, symbols
+duration = 1.0
+charset = ["latin", "cyrillic"]
 
 [artwork]
-size = 96
-opacity = 0.8              # 0 = hidden (left-align text), 1 = fully visible
+size = 120
+opacity = 0.9
 
 [ripple]
 color = "#AAAAFFFF"
-radius = 60
+radius = 80
 duration = 0.4
-idle = 1.3
+idle = 1.5
 ```
-
-All fields are optional. Missing values use sensible defaults.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

Rewrite the Configuration section of README.md with comprehensive documentation for all config options.

## Changes

- Add detailed tables for every config section (`text`, `artwork`, `ripple`, `screen`)
- Document text style inheritance chain (`default` → `title`/`artist`/`lyric`/`highlight`)
- Add screen selection reference table with all 6 options
- Document config file search paths (`~/.config/lyra/`, `~/.lyra/`, `$XDG_CONFIG_HOME`)
- Note that `charset` accepts both single string and array
- Add full example config
- Note that Homebrew installs completions automatically

## Test Plan

- [x] No code changes — documentation only