### PR TITLE
docs: document [ai] config section and includes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Alternative paths: `~/.lyra/config.toml`, `$XDG_CONFIG_HOME/lyra/config.toml`
 |---|---|---|---|
 | `screen` | string / int | `"main"` | Which display to use (see [Screen selection](#screen-selection)) |
 | `wallpaper` | string | — | Video file path. Relative to config dir or absolute |
-| `includes` | array | — | List of TOML files to merge (relative to config dir or absolute) |
+| `includes` | array | — | TOML-only: list of additional TOML files to merge (ignored for `config.json`; paths relative to config dir or absolute) |
 
 ### `[text.default]` — base text style
 


### PR DESCRIPTION
## Summary

Add documentation for the `[ai]` configuration section and the `includes` top-level key to the README.

Closes #59

## Changes

- Add `[ai]` subsection with `endpoint`, `model`, `api_key` field descriptions
- Add tip for separating API keys into a dedicated file via `includes` + `.gitignore`
- Add `includes` to the top-level config table
- Add `[ai]` block and `includes` to the full TOML example

## Test Plan

- [ ] Verify README renders correctly on GitHub