### PR TITLE
docs: update README with brew services auto-start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,19 @@ lyra daemon      # run in foreground (debug)
 lyra version     # show version
 ```
 
-### Login item
+### Auto-start
 
 ```sh
-lyra service install    # auto-start on login
+# via Homebrew (recommended for Homebrew installs)
+brew services start lyra
+brew services stop lyra
+
+# or manually (Mint / source-build users)
+lyra service install    # register LaunchAgent directly
 lyra service uninstall
 ```
+
+> **Note:** Both methods use LaunchAgent but with different labels (`homebrew.mxcl.lyra` vs `com.generald.lyra`). Use one approach — do not mix them, or the daemon will run twice.
 
 ### Shell completion
 


### PR DESCRIPTION
## Summary

Replace the "Login item" section with "Auto-start" covering both `brew services` and `lyra service install`.

Closes #63
Supersedes #68

## Changes

- Document `brew services start/stop lyra` as recommended for Homebrew users
- Keep `lyra service install/uninstall` for Mint / source-build users
- Add note about different LaunchAgent labels to prevent double-running

## Related

- GeneralD/homebrew-tap#4 — adds `service do` block to the formula