### PR TITLE
fix: unify User-Agent header across all API clients

### DIFF
--- a/Sources/LRCLibService/LRCLibAPI.swift
+++ b/Sources/LRCLibService/LRCLibAPI.swift
@@ -9,7 +9,7 @@ public enum LRCLibAPI {
 extension LRCLibAPI: URLRequestConvertible {
     public func asURLRequest() throws -> URLRequest {
         var request = try URLRequest(url: Self.baseURL + path, method: .get)
-        request.setValue("now-playing/1.0", forHTTPHeaderField: "User-Agent")
+        request.setValue("lyra (https://github.com/GeneralD/lyra)", forHTTPHeaderField: "User-Agent")
         return try URLEncoding.default.encode(request, with: parameters)
     }
 }

--- a/Sources/LRCLibService/LRCLibHealthCheck.swift
+++ b/Sources/LRCLibService/LRCLibHealthCheck.swift
@@ -9,7 +9,7 @@ extension LRCLibAPI: HealthCheckable {
             return HealthCheckResult(status: .fail, detail: "invalid URL")
         }
         var request = URLRequest(url: url)
-        request.setValue("now-playing/1.0", forHTTPHeaderField: "User-Agent")
+        request.setValue("lyra (https://github.com/GeneralD/lyra)", forHTTPHeaderField: "User-Agent")
         request.timeoutInterval = 10
 
         let start = ContinuousClock.now

--- a/Sources/MusicBrainzService/MusicBrainzAPI.swift
+++ b/Sources/MusicBrainzService/MusicBrainzAPI.swift
@@ -8,7 +8,7 @@ public enum MusicBrainzAPI {
 extension MusicBrainzAPI: URLRequestConvertible {
     public func asURLRequest() throws -> URLRequest {
         var request = try URLRequest(url: Self.baseURL + path, method: .get)
-        request.setValue("lyra/1.0 (https://github.com/GeneralD/lyra)", forHTTPHeaderField: "User-Agent")
+        request.setValue("lyra (https://github.com/GeneralD/lyra)", forHTTPHeaderField: "User-Agent")
         return try URLEncoding.default.encode(request, with: parameters)
     }
 }

--- a/Sources/MusicBrainzService/MusicBrainzHealthCheck.swift
+++ b/Sources/MusicBrainzService/MusicBrainzHealthCheck.swift
@@ -9,7 +9,7 @@ extension MusicBrainzAPI: HealthCheckable {
             return HealthCheckResult(status: .fail, detail: "invalid URL")
         }
         var request = URLRequest(url: url)
-        request.setValue("lyra/1.0 (https://github.com/GeneralD/lyra)", forHTTPHeaderField: "User-Agent")
+        request.setValue("lyra (https://github.com/GeneralD/lyra)", forHTTPHeaderField: "User-Agent")
         request.timeoutInterval = 10
 
         let start = ContinuousClock.now


### PR DESCRIPTION
## Summary

Unify all API clients to use `lyra (https://github.com/GeneralD/lyra)` as User-Agent.

Closes #66

## Changes

- `LRCLibAPI` / `LRCLibHealthCheck`: `now-playing/1.0` → `lyra (...)`
- `MusicBrainzAPI` / `MusicBrainzHealthCheck`: `lyra/1.0 (...)` → `lyra (...)`

4 files, 4 lines changed. No new modules or version.txt changes.