### PR TITLE
fix: resolve compiler warnings in RootCommand and StartCommand

### DIFF
--- a/Sources/CLI/Commands/RootCommand.swift
+++ b/Sources/CLI/Commands/RootCommand.swift
@@ -37,6 +37,6 @@ struct VersionCommand: ParsableCommand {
     )
 
     func run() {
-        print(RootCommand.configuration.version ?? "unknown")
+        print(RootCommand.configuration.version)
     }
 }

--- a/Sources/CLI/Commands/StartCommand.swift
+++ b/Sources/CLI/Commands/StartCommand.swift
@@ -32,7 +32,7 @@ struct RestartCommand: ParsableCommand {
 
     func run() throws {
         ProcessManager.stopExisting()
-        var start = StartCommand()
+        let start = StartCommand()
         try start.run()
     }
 }


### PR DESCRIPTION
## Summary

- Remove unnecessary `?? \"unknown\"` on non-optional `String` in `VersionCommand.run()`
- Change `var` to `let` for immutable `StartCommand` in `RestartCommand.run()`

## Test plan

- [x] `swift build` produces zero warnings
- [x] All 150 tests pass

Closes #109