### PR TITLE
docs: add track command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ lyra config template  # print default config to stdout
 lyra config init      # create config file with defaults
 lyra config edit      # open config in $EDITOR
 lyra config open      # open config in GUI app
+
+lyra track            # show now-playing info as JSON
+lyra track -r         # resolve metadata (MusicBrainz/regex)
+lyra track -l         # include lyrics (LRCLIB)
+lyra track -rl        # resolve + lyrics
 ```
 
 ### Auto-start


### PR DESCRIPTION
## 概要

#149 で追加した `lyra track` コマンドの Usage セクションへの記載が漏れていたため追加。

## 変更内容

- README.md の Usage セクションに `lyra track` / `-r` / `-l` / `-rl` を追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the new `lyra track` command, which outputs now-playing information with optional metadata resolution and lyrics retrieval capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->