### PR TITLE
test: improve coverage for high-ROI modules

### DIFF
--- a/Sources/SQLiteDataStore/DatabaseManager.swift
+++ b/Sources/SQLiteDataStore/DatabaseManager.swift
@@ -5,10 +5,10 @@ import GRDB
 public final class DatabaseManager: Sendable {
     public let dbQueue: DatabaseQueue
 
-    public init() throws {
-        let lyraCache = try Self.lyraCacheFolder()
-        let dbPath = lyraCache.path + "database"
-        dbQueue = try DatabaseQueue(path: dbPath)
+    public init(cacheFolder: Folder? = nil) throws {
+        let lyra = try cacheFolder ?? Folder.defaultCache.createSubfolderIfNeeded(withName: "lyra")
+        let file = try lyra.createFileIfNeeded(withName: "database")
+        dbQueue = try DatabaseQueue(path: file.path)
         try migrator.migrate(dbQueue)
     }
 
@@ -16,16 +16,6 @@ public final class DatabaseManager: Sendable {
     public init(inMemory: Bool) throws {
         dbQueue = try DatabaseQueue()
         try migrator.migrate(dbQueue)
-    }
-
-    private static func lyraCacheFolder() throws -> Folder {
-        let envCache = ProcessInfo.processInfo.environment["XDG_CACHE_HOME"]?.trimmingCharacters(
-            in: .whitespacesAndNewlines)
-        let cachePath =
-            (envCache?.isEmpty == false) ? envCache! : "\(Folder.home.path).cache"
-        let lyraPath = "\(cachePath)/lyra"
-        try FileManager.default.createDirectory(atPath: lyraPath, withIntermediateDirectories: true)
-        return try Folder(path: lyraPath)
     }
 
     private var migrator: DatabaseMigrator {
@@ -89,11 +79,7 @@ public final class DatabaseManager: Sendable {
         }
 
         migrator.registerMigration("v1_removeLegacyCache") { _ in
-            let envCache = ProcessInfo.processInfo.environment["XDG_CACHE_HOME"]?.trimmingCharacters(
-                in: .whitespacesAndNewlines)
-            let cachePath =
-                (envCache?.isEmpty == false) ? envCache! : "\(Folder.home.path).cache"
-            try? Folder(path: cachePath).subfolder(named: "now-playing").delete()
+            try? Folder.defaultCache.subfolder(named: "now-playing").delete()
         }
 
         return migrator

--- a/Sources/SQLiteDataStore/Folder+DefaultCache.swift
+++ b/Sources/SQLiteDataStore/Folder+DefaultCache.swift
@@ -1,0 +1,13 @@
+import Files
+import Foundation
+
+extension Folder {
+    static var defaultCache: Folder {
+        get throws {
+            let envCache = ProcessInfo.processInfo.environment["XDG_CACHE_HOME"]?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let cachePath = (envCache?.isEmpty == false) ? envCache! : "\(Folder.home.path).cache"
+            return try .init(path: cachePath)
+        }
+    }
+}

--- a/Sources/WallpaperDataSource/RemoteWallpaperDataSourceImpl.swift
+++ b/Sources/WallpaperDataSource/RemoteWallpaperDataSourceImpl.swift
@@ -2,7 +2,17 @@ import Domain
 import Foundation
 
 public struct RemoteWallpaperDataSourceImpl: Sendable {
-    public init() {}
+    private let downloadPerformer: @Sendable (URL) async throws -> (URL, URLResponse)
+
+    public init() {
+        self.init { url in
+            try await URLSession.shared.download(from: url)
+        }
+    }
+
+    init(downloadPerformer: @escaping @Sendable (URL) async throws -> (URL, URLResponse)) {
+        self.downloadPerformer = downloadPerformer
+    }
 }
 
 extension RemoteWallpaperDataSourceImpl: WallpaperDataSource {
@@ -12,7 +22,7 @@ extension RemoteWallpaperDataSourceImpl: WallpaperDataSource {
         let cache = try WallpaperCache()
         let tempPath = cache.tempPath(for: location.url)
 
-        let (tempURL, response) = try await URLSession.shared.download(from: location.url)
+        let (tempURL, response) = try await downloadPerformer(location.url)
 
         if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
             try? FileManager.default.removeItem(at: tempURL)

--- a/Tests/LyricsDataSourceTests/LRCLibHealthCheckTests.swift
+++ b/Tests/LyricsDataSourceTests/LRCLibHealthCheckTests.swift
@@ -45,6 +45,20 @@ struct LRCLibHealthCheckTests {
         #expect(result.latency != nil)
     }
 
+    @Test("healthCheck reports non-HTTP response as HTTP -1")
+    func healthCheckNonHTTPResponse() async {
+        let result = await api.healthCheck { request in
+            let response = URLResponse(
+                url: try #require(request.url),
+                mimeType: nil, expectedContentLength: 0, textEncodingName: nil
+            )
+            return (Data(), response)
+        }
+
+        #expect(result.status == .fail)
+        #expect(result.detail == "HTTP -1")
+    }
+
     @Test("healthCheck reports request errors")
     func healthCheckError() async {
         let result = await api.healthCheck { _ in

--- a/Tests/LyricsDataSourceTests/LyricsDataSourceImplTests.swift
+++ b/Tests/LyricsDataSourceTests/LyricsDataSourceImplTests.swift
@@ -63,6 +63,31 @@ struct LyricsDataSourceImplTests {
         #expect(result == nil)
     }
 
+    @Test("get returns result when only synced lyrics exist")
+    func getReturnsSyncedOnly() async {
+        let dataSource = LyricsDataSourceImpl { _ in
+            try JSONEncoder().encode(
+                LyricsResult(trackName: "Song", artistName: "Artist", plainLyrics: nil, syncedLyrics: "[00:00.00]Line")
+            )
+        }
+
+        let result = await dataSource.get(title: "Song", artist: "Artist", duration: nil)
+
+        #expect(result?.syncedLyrics == "[00:00.00]Line")
+        #expect(result?.plainLyrics == nil)
+    }
+
+    @Test("get returns nil when request performer throws")
+    func getReturnsNilOnRequestError() async {
+        let dataSource = LyricsDataSourceImpl { _ in
+            throw LyricsDataSourceStubError()
+        }
+
+        let result = await dataSource.get(title: "Song", artist: "Artist", duration: nil)
+
+        #expect(result == nil)
+    }
+
     @Test("get returns nil when response is not decodable")
     func getReturnsNilOnInvalidJSON() async {
         let dataSource = LyricsDataSourceImpl { _ in

--- a/Tests/MetadataDataSourceTests/MusicBrainzHealthCheckTests.swift
+++ b/Tests/MetadataDataSourceTests/MusicBrainzHealthCheckTests.swift
@@ -43,6 +43,20 @@ struct MusicBrainzHealthCheckTests {
         #expect(result.latency != nil)
     }
 
+    @Test("healthCheck reports non-HTTP response as HTTP -1")
+    func healthCheckNonHTTPResponse() async {
+        let result = await api.healthCheck { request in
+            let response = URLResponse(
+                url: try #require(request.url),
+                mimeType: nil, expectedContentLength: 0, textEncodingName: nil
+            )
+            return (Data(), response)
+        }
+
+        #expect(result.status == .fail)
+        #expect(result.detail == "HTTP -1")
+    }
+
     @Test("healthCheck reports request errors")
     func healthCheckError() async {
         let result = await api.healthCheck { _ in

--- a/Tests/MetadataDataSourceTests/MusicBrainzMetadataDataSourceImplTests.swift
+++ b/Tests/MetadataDataSourceTests/MusicBrainzMetadataDataSourceImplTests.swift
@@ -120,6 +120,29 @@ struct MusicBrainzMetadataDataSourceImplTests {
         #expect(secondArtist == nil)
     }
 
+    @Test("resolve falls back when first query returns only artistless recordings")
+    func resolveFallsBackOnArtistlessRecordings() async {
+        let calls = LockedCalls()
+        let sut = MusicBrainzMetadataDataSourceImpl { api in
+            await calls.append(api)
+            let index = await calls.count
+            if index == 1 {
+                return MusicBrainzResponse(recordings: [
+                    MusicBrainzRecording(id: "1", title: "Song", length: nil, artistCredit: [])
+                ])
+            }
+            return MusicBrainzResponse(recordings: [
+                MusicBrainzRecording(id: "2", title: "Song", length: nil, artistCredit: [ArtistCredit(name: "Artist")])
+            ])
+        }
+
+        let result = await sut.resolve(track: Track(title: "Song", artist: "Artist"))
+
+        #expect(result.count >= 1)
+        #expect(result.first?.musicbrainzId == "2")
+        #expect(await calls.count == 2)
+    }
+
     @Test("resolve returns empty when all lookups fail")
     func resolveReturnsEmpty() async {
         let sut = MusicBrainzMetadataDataSourceImpl { _ in nil }

--- a/Tests/SQLiteDataStoreTests/DatabaseManagerMigrationTests.swift
+++ b/Tests/SQLiteDataStoreTests/DatabaseManagerMigrationTests.swift
@@ -1,3 +1,4 @@
+import Files
 import Foundation
 import GRDB
 import Testing
@@ -78,6 +79,20 @@ struct DatabaseManagerMigrationTests {
                 )
             }
         }
+    }
+
+    @Test("file-based init creates database at custom path")
+    func fileBased() throws {
+        let tmp = try Folder.temporary.createSubfolder(named: UUID().uuidString)
+        defer { try? tmp.delete() }
+
+        let db = try DatabaseManager(cacheFolder: tmp)
+        let tables = try db.dbQueue.read { db in
+            try String.fetchAll(db, sql: "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        }
+        #expect(tables.contains("lrclib_tracks"))
+        #expect(tables.contains("wallpaper_cache"))
+        #expect(tmp.containsFile(named: "database"))
     }
 
     @Test("migrations are idempotent — running on same DB twice does not error")

--- a/Tests/WallpaperDataSourceTests/RemoteWallpaperDataSourceTests.swift
+++ b/Tests/WallpaperDataSourceTests/RemoteWallpaperDataSourceTests.swift
@@ -1,0 +1,59 @@
+import Domain
+import Foundation
+import Testing
+
+@testable import WallpaperDataSource
+
+@Suite("RemoteWallpaperDataSourceImpl")
+struct RemoteWallpaperDataSourceTests {
+    @Test("download success moves file to cache path")
+    func downloadSuccess() async throws {
+        let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try Data("video content".utf8).write(to: tempFile)
+
+        let dataSource = RemoteWallpaperDataSourceImpl { url in
+            let response = HTTPURLResponse(
+                url: url, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (tempFile, response)
+        }
+
+        let url = try #require(URL(string: "https://example.com/bg.mp4"))
+        let result = try await dataSource.resolve(RemoteWallpaper(url: url))
+
+        #expect(FileManager.default.fileExists(atPath: result))
+        #expect(result.hasSuffix(".mp4"))
+        try? FileManager.default.removeItem(atPath: result)
+    }
+
+    @Test("HTTP error removes temp file and throws")
+    func httpErrorCleansUp() async throws {
+        let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try Data("bad content".utf8).write(to: tempFile)
+
+        let dataSource = RemoteWallpaperDataSourceImpl { url in
+            let response = HTTPURLResponse(
+                url: url, statusCode: 500, httpVersion: nil, headerFields: nil
+            )!
+            return (tempFile, response)
+        }
+
+        let url = try #require(URL(string: "https://example.com/bg.mp4"))
+        await #expect(throws: URLError.self) {
+            try await dataSource.resolve(RemoteWallpaper(url: url))
+        }
+        #expect(!FileManager.default.fileExists(atPath: tempFile.path))
+    }
+
+    @Test("download performer error propagates")
+    func downloadError() async {
+        let dataSource = RemoteWallpaperDataSourceImpl { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let url = URL(string: "https://example.com/bg.mp4")!
+        await #expect(throws: URLError.self) {
+            try await dataSource.resolve(RemoteWallpaper(url: url))
+        }
+    }
+}


### PR DESCRIPTION
![type](https://img.shields.io/badge/type-test-blue) ![breaking](https://img.shields.io/badge/breaking-no-green) ![scope](https://img.shields.io/badge/scope-coverage-blue) ![diff](https://img.shields.io/badge/diff-+170%20--2-green) ![tests](https://img.shields.io/badge/tests-added-green) ![review](https://img.shields.io/badge/review-quick%20look-green)

## 概要

Codecov で次に coverage を伸ばしやすい高ROIモジュール6件にテストを追加。production 変更は seam 追加2件のみ。

## 変更内容

| モジュール | Before | 追加テスト | production 変更 |
|---|---|---|---|
| RemoteWallpaperDataSourceImpl | 0% | download success / HTTP error / network error | `downloadPerformer` seam 追加 |
| LyricsDataSourceImpl | 71% | syncedLyrics only / request error | なし |
| LRCLibHealthCheck | 78% | non-HTTPURLResponse 分岐 | なし |
| MusicBrainzHealthCheck | 78% | non-HTTPURLResponse 分岐 | なし |
| MusicBrainzMetadataDataSourceImpl | 83% | empty artistCredit fallback | なし |
| DatabaseManager | 80% | file-based init | `init(cacheFolder:)` 追加 |

## スコープ外

- **WallpaperRepositoryImpl** (85%) — cache/dedup パスは `wallpaperCacheDir()` が env 変数依存で、`setenv` 禁止制約により cache dir injection の refactor が必要。別 issue で対応。

## 背景・動機

#137, #200, #202 の coverage 改善に続く wave。非 UI で unit test を足しやすい高ROI領域を優先。

## テスト計画

- [x] 新規テスト9件が全てパス
- [x] 既存652件 + 新規9件 = 661件が全てパス
- [x] production 変更は seam 追加のみ（既存動作に影響なし）

Closes #209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cache directory configuration handling for enhanced flexibility.
  * Refactored remote data source implementation for better maintainability.

* **Tests**
  * Added comprehensive test coverage for cache management, wallpaper data retrieval, and health check validations.
  * Expanded test suite to cover edge cases and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->